### PR TITLE
Release 0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/hardware-wallet-cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/hardware-wallet-cli",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "ISC",
       "dependencies": {
         "@dfinity/agent": "^0.11.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "format": "prettier --write .",
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc --build",
-    "prepublish": "npm run build",
+    "prepack": "npm run build",
     "clean": "tsc --build --clean",
     "refresh": "rm -rf ./node_modules ./package-lock.json && npm install",
     "execute": "ts-node ./index.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/hardware-wallet-cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A CLI to interact with the Internet Computer App on Ledger Nano S/X devices.",
   "main": "./build/index.js",
   "scripts": {


### PR DESCRIPTION
# Motivation
We would like to publish a new version with the following fix:

- The executable was not included in the packfile, so `npm install -g` did not install the binary.  This is addressed by #3 .

# Changes
- Bump patch version
- Change prepublish to prepack per discussion