### PR TITLE
Only list neurons with non-zero voting power

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -369,7 +369,9 @@ async function listNeurons() {
 
   if (neurons.length > 0) {
     neurons.forEach((n) => {
-      log(`Neuron ID: ${n.neuronId}`);
+      if (n.votingPower > 0) {
+        log(`Neuron ID: ${n.neuronId} Voting power: ${n.votingPower} Hotkeys: ${n.fullNeuron?.hotKeys}`);
+      }
     });
   } else {
     ok("No neurons found.");


### PR DESCRIPTION
Also output the voting power and hotkeys.

IIRC the old CLI tool (before being split into its own repo) actually had this behavior already. Right now, all I'm getting is a list of neuron IDs with no extra information, the vast majority of which have zero ICP staked.