### PR TITLE
build: bump semver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,9 @@
         "esbuild": "^0.17.4",
         "prettier": "^2.6.2",
         "ts-node": "^10.9.1"
+      },
+      "engines": {
+        "node": ">= 18.13.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1283,14 +1286,6 @@
         "semver": "^5.4.1"
       }
     },
-    "node_modules/node-abi/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/node-addon-api": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
@@ -1519,9 +1514,9 @@
       ]
     },
     "node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -2076,7 +2071,7 @@
         "@ledgerhq/errors": "^6.10.0",
         "@ledgerhq/logs": "^6.10.0",
         "rxjs": "6",
-        "semver": "^7.3.5"
+        "semver": "^7.5.3"
       }
     },
     "@ledgerhq/errors": {
@@ -2648,14 +2643,7 @@
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
       "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
       "requires": {
-        "semver": "^5.4.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
+        "semver": "^7.5.3"
       }
     },
     "node-addon-api": {
@@ -2818,9 +2806,9 @@
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
       "requires": {
         "lru-cache": "^6.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -60,5 +60,8 @@
   },
   "bin": {
     "ic-hardware-wallet": "./dist/index.js"
+  },
+  "overrides": {
+    "semver": "^7.5.3"
   }
 }


### PR DESCRIPTION
# Motivation

Fix semver vulnerable to Regular Expression Denial of Service [CVE-2022-25883](https://github.com/advisories/GHSA-c2qf-rxjj-qqgw).

# Notes

I did not performed any tests.

# Changes

- pin `semver` to v7.3.5
