### PR TITLE
Fix: CLI not working

### DIFF
--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -13,16 +13,20 @@ if (!existsSync(dist)) {
 const script = await esbuild.build({
   entryPoints: ["src/index.ts"],
   bundle: true,
-  minify: true,
+  minify: false,
   platform: "node",
   write: false,
   plugins: [
     NodeResolve.NodeResolvePlugin({
       extensions: [".ts", ".js"],
       onResolved: (resolved) => {
-        // We need to exclude node_modules from the bundle
-        // otherwise ledgerhq thinks we're in the browser.
-        if (resolved.includes("node_modules")) {
+        // We need to exclude hw-transport-node-hid-noevents for
+        // the bindings library to work properly.
+        // https://github.com/TooTallNate/node-bindings/issues/65#issuecomment-637495802
+        if (
+          resolved.includes("node_modules") &&
+          resolved.includes("hw-transport-node-hid-noevents")
+        ) {
           return {
             external: true,
           };

--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -13,7 +13,7 @@ if (!existsSync(dist)) {
 const script = await esbuild.build({
   entryPoints: ["src/index.ts"],
   bundle: true,
-  minify: false,
+  minify: true,
   platform: "node",
   write: false,
   plugins: [


### PR DESCRIPTION
The cli is not working because some dependency is not loaded properly.

I was able to replicate and fix the problem locally by adding it to the build. But then, there was one dependency (bindings) that wasn't working when adding it to the build. This dependency is inside `hw-transport-node-hid-noevents`, that's why it's the only one not added to the build.