### PR TITLE
Fix: Parcel build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@
 build/
 dist/
 node_modules/
+.parcel-cache/
 
 **/*.rs.bk

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.3.0",
   "description": "A CLI to interact with the Internet Computer App on Ledger Nano S/X devices.",
   "main": "./dist/index.js",
+  "source": "./src/index.js",
   "files": [
     "dist/index.js",
     "README.md",


### PR DESCRIPTION
# Motivation

Parcel build failed.

It was missing the "source" in package.json.

I reverted the changes in package.json because I was trying other things and then I forgot to add this part again.

# Changes

* Add "source" to package.json
* Add parce-cache to git ignore.