### PR TITLE
Fix: Parcel build 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,5 +65,14 @@
   },
   "overrides": {
     "semver": "^7.5.3"
+  },
+  "targets": {
+    "main": {
+      "includeNodeModules": [
+        "@ledgerhq/hw-transport-webhid",
+        "@ledgerhq/hw-transport-node-hid-noevents",
+        "@ledgerhq/hw-transport"
+      ]
+    }
   }
 }


### PR DESCRIPTION
Build still isn't working when published to npm.

In this PR, I include the node modules in the bundle that are causing problems.

They are bundled with `var` instead of `let` and `const`. I expect this to fix the issue.

Locally all works as expected.