### PR TITLE
chore: upgrade @icp-sdk/core to 5.2.1 and refactor Icrc21Agent to use update()

### DIFF
--- a/examples/icrc21-swap/package.json
+++ b/examples/icrc21-swap/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@dfinity/icrc21-agent": "workspace:*",
     "@dfinity/ledger-wallet-identity": "workspace:*",
-    "@icp-sdk/core": "^5.0.0"
+    "@icp-sdk/core": "^5.2.1"
   },
   "devDependencies": {
     "buffer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "ISC",
   "devDependencies": {
     "@dfinity/pic": "^0.21.0",
-    "@icp-sdk/core": "^5.0.0",
+    "@icp-sdk/core": "^5.2.1",
     "@types/google-protobuf": "^3.15.6",
     "prettier": "^2.6.2",
     "ts-node": "^10.9.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,7 +29,7 @@
     "@dfinity/utils": "^4.1.0",
     "@icp-sdk/canisters": "^3.2.0",
     "@icp-sdk/core": "^5.2.1",
-    "@zondax/ledger-icp": "^3.2.6",
+    "@zondax/ledger-icp": "^3.2.8",
     "chalk": "^4.1.2",
     "commander": "^9.0.0",
     "node-hid": "^3.2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,7 @@
     "@dfinity/ledger-wallet-identity": "workspace:*",
     "@dfinity/utils": "^4.1.0",
     "@icp-sdk/canisters": "^3.2.0",
-    "@icp-sdk/core": "^5.0.0",
+    "@icp-sdk/core": "^5.2.1",
     "@zondax/ledger-icp": "^3.2.6",
     "chalk": "^4.1.2",
     "commander": "^9.0.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -40,13 +40,7 @@ import {
   hexStringToBytes,
 } from "./utils";
 import { CANDID_PARSER_VERSION, HOTKEY_PERMISSIONS } from "./constants";
-import {
-  AnonymousIdentity,
-  Identity,
-  Certificate,
-  lookupResultToBuffer,
-} from "@icp-sdk/core/agent";
-import type { v4ResponseBody } from "@icp-sdk/core/agent";
+import { AnonymousIdentity, Identity } from "@icp-sdk/core/agent";
 import {
   SnsGovernanceCanister,
   SnsGovernanceDid,
@@ -865,42 +859,15 @@ async function icrc21Call({
 
   const icrc21Agent = await Icrc21Agent.create(identity, new URL(network));
 
-  const submitResponse = await icrc21Agent.call(canisterId, {
+  const result = await icrc21Agent.update(canisterId, {
     methodName: method,
     arg: new Uint8Array(hexStringToBytes(arg)),
     effectiveCanisterId: canisterId,
   });
 
-  const requestId = submitResponse.requestId;
-  ok(`Request ID: ${bytesToHexString(Array.from(requestId))}`);
-
-  // Extract reply from the response certificate
-  const body = submitResponse.response.body as v4ResponseBody | undefined;
-  if (body?.certificate) {
-    const certBytes = new Uint8Array(body.certificate);
-    const rootKey = icrc21Agent.rootKey;
-    if (rootKey) {
-      const cert = await Certificate.create({
-        certificate: certBytes,
-        rootKey,
-        principal: { canisterId },
-      });
-      const replyBytes = lookupResultToBuffer(
-        cert.lookup_path([
-          new TextEncoder().encode("request_status"),
-          requestId,
-          new TextEncoder().encode("reply"),
-        ])
-      );
-      if (replyBytes) {
-        const replyHex = bytesToHexString(
-          Array.from(new Uint8Array(replyBytes))
-        );
-        ok(`Reply: ${replyHex}`);
-        console.log(`Decode with: didc decode ${replyHex}`);
-      }
-    }
-  }
+  const replyHex = bytesToHexString(Array.from(result.reply));
+  ok(`Reply: ${replyHex}`);
+  console.log(`Decode with: didc decode ${replyHex}`);
 }
 
 async function main() {

--- a/packages/icrc21-agent/README.md
+++ b/packages/icrc21-agent/README.md
@@ -57,7 +57,7 @@ See the [ICRC-21 swap example](https://github.com/dfinity/hardware-wallet-cli/tr
 
 ### Direct call
 
-You can also use `Icrc21Agent.call()` directly without an Actor.
+You can also use `Icrc21Agent.update()` directly without an Actor. This returns the certified reply bytes directly.
 
 ```typescript
 import { Icrc21Agent } from "@dfinity/icrc21-agent";
@@ -74,16 +74,18 @@ const arg = IDL.encode(
   ["ckBTC", "ICP", 10_000_000n]
 );
 
-const response = await agent.call(canisterId, {
+const result = await agent.update(canisterId, {
   methodName: "swap",
   arg,
   effectiveCanisterId: canisterId,
 });
+
+const reply = IDL.decode([IDL.Text], result.reply)[0];
 ```
 
 ## Limitations
 
-- Only **update calls** (`call()`) are supported. `query()`, `readState()`, and `status()` are not implemented.
+- Only **update calls** (`update()`, `call()`) are supported. `query()`, `readState()`, and `status()` are not implemented.
 - Consent messages are requested in English with `FieldsDisplay` format (a constraint of current Ledger firmware).
 - The target canister must implement the [`icrc21_canister_call_consent_message`](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/ICRC-21/icrc_21_consent_msg.md) method.
 

--- a/packages/icrc21-agent/package.json
+++ b/packages/icrc21-agent/package.json
@@ -31,7 +31,7 @@
     "directory": "packages/icrc21-agent"
   },
   "dependencies": {
-    "@icp-sdk/core": "^5.0.0"
+    "@icp-sdk/core": "^5.2.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/icrc21-agent/src/icrc21-agent.ts
+++ b/packages/icrc21-agent/src/icrc21-agent.ts
@@ -5,19 +5,15 @@ import type {
   Identity,
   SubmitResponse,
   CallRequest,
-  v4ResponseBody,
   ApiQueryResponse,
   QueryFields,
   ReadStateOptions,
   ReadStateResponse,
+  UpdateResult,
+  PollingOptions,
 } from "@icp-sdk/core/agent";
 import type { JsonObject } from "@icp-sdk/core/candid";
-import {
-  HttpAgent,
-  AnonymousIdentity,
-  Certificate,
-  lookupResultToBuffer,
-} from "@icp-sdk/core/agent";
+import { HttpAgent, AnonymousIdentity } from "@icp-sdk/core/agent";
 import { IDL } from "@icp-sdk/core/candid";
 import type { Icrc21Identity } from "./icrc21-identity";
 
@@ -109,14 +105,15 @@ export class Icrc21Agent implements Agent {
     return this.signingAgent.getPrincipal();
   }
 
-  /** Executes a canister call through the ICRC-21 consent message flow. */
-  async call(
+  /** Executes an update call through the ICRC-21 consent message flow and returns the certified reply. */
+  async update(
     canisterIdArg: Principal | string,
-    fields: CallOptions
-  ): Promise<SubmitResponse> {
+    fields: CallOptions,
+    pollingOptions?: PollingOptions
+  ): Promise<UpdateResult> {
     const canisterId = Principal.from(canisterIdArg);
 
-    // Fetch the consent message from the canister
+    // Fetch the consent message from the canister.
     // Returns the request and the certificate that contains the response.
     const { request, certificate } = await this.fetchConsentMessage(
       canisterId,
@@ -127,16 +124,28 @@ export class Icrc21Agent implements Agent {
     this.identity.flagUpcomingIcrc21(request, certificate);
 
     // Send the canister call via the signing agent which triggers ICRC-21 approval.
-    const result = await this.signingAgent.call(canisterId, {
-      methodName: fields.methodName,
-      arg: fields.arg,
-      effectiveCanisterId: fields.effectiveCanisterId,
-    });
+    return this.signingAgent.update(
+      canisterId,
+      {
+        methodName: fields.methodName,
+        arg: fields.arg,
+        effectiveCanisterId: fields.effectiveCanisterId,
+      },
+      pollingOptions
+    );
+  }
 
-    // Verify the call wasn't rejected by the canister
-    this.checkForRejection(await this.certificateLookup(result, canisterId));
-
-    return result;
+  /** Required by the Agent interface. Prefer {@link update} for direct usage. */
+  async call(
+    canisterIdArg: Principal | string,
+    fields: CallOptions
+  ): Promise<SubmitResponse> {
+    const result = await this.update(canisterIdArg, fields);
+    return {
+      requestId: result.requestDetails?.request_id ?? (new Uint8Array() as any),
+      response: result.callResponse,
+      requestDetails: result.requestDetails,
+    };
   }
 
   /**
@@ -168,84 +177,27 @@ export class Icrc21Agent implements Agent {
       ]
     );
 
-    const consentMessageResponse = await this.anonymousAgent.call(canisterId, {
+    // Use update() to get the certified result directly.
+    // This handles polling and throws on rejection automatically.
+    const result = await this.anonymousAgent.update(canisterId, {
       methodName: "icrc21_canister_call_consent_message",
       arg: consentMessageRequest,
       effectiveCanisterId: canisterId,
     });
 
-    if (!consentMessageResponse.response.body) {
-      throw new Error("No response body from consent message call");
-    }
+    // Check for ICRC-21 specific errors in the reply
+    this.checkForIcrc21Error(result.reply);
 
-    const certificate = new Uint8Array(
-      (consentMessageResponse.response.body as v4ResponseBody).certificate
-    );
-
-    const lookup = await this.certificateLookup(
-      consentMessageResponse,
-      canisterId
-    );
-    this.checkForRejection(lookup);
-    this.checkForIcrc21Error(lookup);
-
-    const request = consentMessageResponse.requestDetails;
+    const request = result.requestDetails;
     if (!request) {
       throw new Error("Missing request details from consent message call");
     }
 
-    return { request, certificate };
-  }
-
-  /** Returns a lookup function for reading fields from a call response certificate. */
-  private async certificateLookup(
-    response: SubmitResponse,
-    canisterId: Principal
-  ): Promise<(field: string) => Uint8Array | undefined> {
-    const rootKey = this.anonymousAgent.rootKey;
-    if (!rootKey) return () => undefined;
-
-    const body = response.response.body as v4ResponseBody | undefined;
-    if (!body?.certificate) return () => undefined;
-
-    const cert = await Certificate.create({
-      certificate: new Uint8Array(body.certificate),
-      rootKey,
-      principal: { canisterId },
-    });
-
-    const requestId = response.requestId;
-    return (field: string) =>
-      lookupResultToBuffer(
-        cert.lookup_path([
-          new TextEncoder().encode("request_status"),
-          requestId,
-          new TextEncoder().encode(field),
-        ])
-      );
-  }
-
-  /** Throws if the certificate indicates the call was rejected. */
-  private checkForRejection(
-    lookup: (field: string) => Uint8Array | undefined
-  ): void {
-    const statusBytes = lookup("status");
-    if (statusBytes && new TextDecoder().decode(statusBytes) === "rejected") {
-      const rejectMsgBytes = lookup("reject_message");
-      const rejectMsg = rejectMsgBytes
-        ? new TextDecoder().decode(rejectMsgBytes)
-        : "Unknown rejection";
-      throw new Error(`Call rejected: ${rejectMsg}`);
-    }
+    return { request, certificate: result.rawCertificate };
   }
 
   /** Throws if the consent message response contains an ICRC-21 error. */
-  private checkForIcrc21Error(
-    lookup: (field: string) => Uint8Array | undefined
-  ): void {
-    const replyBytes = lookup("reply");
-    if (!replyBytes) return;
-
+  private checkForIcrc21Error(replyBytes: Uint8Array): void {
     const [decoded] = IDL.decode(
       [icrc21_consent_message_response],
       replyBytes

--- a/packages/icrc21-agent/src/icrc21-agent.ts
+++ b/packages/icrc21-agent/src/icrc21-agent.ts
@@ -5,6 +5,7 @@ import type {
   Identity,
   SubmitResponse,
   CallRequest,
+  v4ResponseBody,
   ApiQueryResponse,
   QueryFields,
   ReadStateOptions,
@@ -13,7 +14,12 @@ import type {
   PollingOptions,
 } from "@icp-sdk/core/agent";
 import type { JsonObject } from "@icp-sdk/core/candid";
-import { HttpAgent, AnonymousIdentity } from "@icp-sdk/core/agent";
+import {
+  HttpAgent,
+  AnonymousIdentity,
+  Certificate,
+  lookupResultToBuffer,
+} from "@icp-sdk/core/agent";
 import { IDL } from "@icp-sdk/core/candid";
 import type { Icrc21Identity } from "./icrc21-identity";
 
@@ -140,12 +146,60 @@ export class Icrc21Agent implements Agent {
     canisterIdArg: Principal | string,
     fields: CallOptions
   ): Promise<SubmitResponse> {
-    const result = await this.update(canisterIdArg, fields);
-    return {
-      requestId: result.requestDetails?.request_id ?? (new Uint8Array() as any),
-      response: result.callResponse,
-      requestDetails: result.requestDetails,
-    };
+    const canisterId = Principal.from(canisterIdArg);
+
+    const { request, certificate } = await this.fetchConsentMessage(
+      canisterId,
+      fields
+    );
+    this.identity.flagUpcomingIcrc21(request, certificate);
+
+    const result = await this.signingAgent.call(canisterId, {
+      methodName: fields.methodName,
+      arg: fields.arg,
+      effectiveCanisterId: fields.effectiveCanisterId,
+    });
+
+    await this.checkForRejection(result, canisterId);
+
+    return result;
+  }
+
+  /** Verifies the call response certificate and throws if the canister rejected the call. */
+  private async checkForRejection(
+    response: SubmitResponse,
+    canisterId: Principal
+  ): Promise<void> {
+    const rootKey = this.anonymousAgent.rootKey;
+    if (!rootKey) return;
+
+    const body = response.response.body as v4ResponseBody | undefined;
+    if (!body?.certificate) return;
+
+    const cert = await Certificate.create({
+      certificate: new Uint8Array(body.certificate),
+      rootKey,
+      principal: { canisterId },
+    });
+
+    const requestId = response.requestId;
+    const lookup = (field: string) =>
+      lookupResultToBuffer(
+        cert.lookup_path([
+          new TextEncoder().encode("request_status"),
+          requestId,
+          new TextEncoder().encode(field),
+        ])
+      );
+
+    const statusBytes = lookup("status");
+    if (statusBytes && new TextDecoder().decode(statusBytes) === "rejected") {
+      const rejectMsgBytes = lookup("reject_message");
+      const rejectMsg = rejectMsgBytes
+        ? new TextDecoder().decode(rejectMsgBytes)
+        : "Unknown rejection";
+      throw new Error(`Call rejected: ${rejectMsg}`);
+    }
   }
 
   /**

--- a/packages/icrc21-agent/tests/icrc21-agent.spec.ts
+++ b/packages/icrc21-agent/tests/icrc21-agent.spec.ts
@@ -217,7 +217,7 @@ describe("Icrc21Agent", () => {
     ).rejects.toThrow("UnsupportedCanisterCall");
   });
 
-  it("should throw when the canister call is rejected", async () => {
+  it("should throw when the canister call is rejected via call()", async () => {
     const agent = await Icrc21Agent.create(identity, new URL(gatewayUrl));
 
     const arg = IDL.encode(
@@ -231,7 +231,7 @@ describe("Icrc21Agent", () => {
         arg: new Uint8Array(arg),
         effectiveCanisterId: canisterId,
       })
-    ).rejects.toThrow("rejection");
+    ).rejects.toThrow("Call rejected");
   });
 
   it("should return the signing identity's principal", async () => {

--- a/packages/icrc21-agent/tests/icrc21-agent.spec.ts
+++ b/packages/icrc21-agent/tests/icrc21-agent.spec.ts
@@ -55,6 +55,56 @@ describe("Icrc21Agent", () => {
     expect(result.response).toBeDefined();
   });
 
+  it("should update a canister through the ICRC-21 consent flow and return the reply", async () => {
+    const agent = await Icrc21Agent.create(identity, new URL(gatewayUrl));
+
+    const arg = IDL.encode(
+      [IDL.Text, IDL.Text, IDL.Nat64],
+      ["ckBTC", "ICP", BigInt(10_000_000)]
+    );
+
+    const result = await agent.update(canisterId, {
+      methodName: "swap",
+      arg: new Uint8Array(arg),
+      effectiveCanisterId: canisterId,
+    });
+
+    expect(result.reply).toBeDefined();
+    expect(result.certificate).toBeDefined();
+
+    const decoded = IDL.decode([IDL.Text], result.reply)[0] as string;
+    expect(decoded).toBe("Swapped 10000000 ckBTC for ICP");
+  });
+
+  it("should throw on ICRC-21 error via update()", async () => {
+    const agent = await Icrc21Agent.create(identity, new URL(gatewayUrl));
+
+    await expect(
+      agent.update(canisterId, {
+        methodName: "some_other_method",
+        arg: new Uint8Array(),
+        effectiveCanisterId: canisterId,
+      })
+    ).rejects.toThrow("UnsupportedCanisterCall");
+  });
+
+  it("should throw on canister rejection via update()", async () => {
+    const agent = await Icrc21Agent.create(identity, new URL(gatewayUrl));
+
+    const arg = IDL.encode(
+      [IDL.Text, IDL.Text, IDL.Nat64],
+      ["ICP", "ckBTC", BigInt(2_000_000_000)]
+    );
+
+    await expect(
+      agent.update(canisterId, {
+        methodName: "swap",
+        arg: new Uint8Array(arg),
+        effectiveCanisterId: canisterId,
+      })
+    ).rejects.toThrow("rejection");
+  });
+
   it("should invoke flagUpcomingIcrc21 on the identity", async () => {
     const freshIdentity = new MockIcrc21Identity();
     const agent = await Icrc21Agent.create(freshIdentity, new URL(gatewayUrl));
@@ -181,7 +231,7 @@ describe("Icrc21Agent", () => {
         arg: new Uint8Array(arg),
         effectiveCanisterId: canisterId,
       })
-    ).rejects.toThrow("Call rejected");
+    ).rejects.toThrow("rejection");
   });
 
   it("should return the signing identity's principal", async () => {

--- a/packages/ledger-wallet-identity/package.json
+++ b/packages/ledger-wallet-identity/package.json
@@ -35,10 +35,10 @@
     "directory": "packages/ledger-wallet-identity"
   },
   "dependencies": {
-    "@icp-sdk/core": "^5.0.0",
+    "@icp-sdk/core": "^5.2.1",
     "@ledgerhq/hw-transport-node-hid-noevents": "^6.34.0",
     "@ledgerhq/hw-transport-webhid": "^6.34.0",
-    "@zondax/ledger-icp": "^3.2.6"
+    "@zondax/ledger-icp": "^3.2.8"
   },
   "peerDependencies": {
     "node-hid": "^3.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,8 +11,8 @@ importers:
         specifier: ^0.21.0
         version: 0.21.0
       "@icp-sdk/core":
-        specifier: ^5.0.0
-        version: 5.0.0
+        specifier: ^5.2.1
+        version: 5.2.1
       "@types/google-protobuf":
         specifier: ^3.15.6
         version: 3.15.12
@@ -38,8 +38,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ledger-wallet-identity
       "@icp-sdk/core":
-        specifier: ^5.0.0
-        version: 5.0.0
+        specifier: ^5.2.1
+        version: 5.2.1
     devDependencies:
       buffer:
         specifier: ^6.0.3
@@ -58,13 +58,13 @@ importers:
         version: link:../ledger-wallet-identity
       "@dfinity/utils":
         specifier: ^4.1.0
-        version: 4.1.0(@icp-sdk/core@5.0.0)
+        version: 4.1.0(@icp-sdk/core@5.2.1)
       "@icp-sdk/canisters":
         specifier: ^3.2.0
-        version: 3.4.0(@dfinity/utils@4.1.0(@icp-sdk/core@5.0.0))(@icp-sdk/core@5.0.0)
+        version: 3.4.0(@dfinity/utils@4.1.0(@icp-sdk/core@5.2.1))(@icp-sdk/core@5.2.1)
       "@icp-sdk/core":
-        specifier: ^5.0.0
-        version: 5.0.0
+        specifier: ^5.2.1
+        version: 5.2.1
       "@zondax/ledger-icp":
         specifier: ^3.2.6
         version: 3.2.8
@@ -94,14 +94,14 @@ importers:
   packages/icrc21-agent:
     dependencies:
       "@icp-sdk/core":
-        specifier: ^5.0.0
-        version: 5.0.0
+        specifier: ^5.2.1
+        version: 5.2.1
 
   packages/ledger-wallet-identity:
     dependencies:
       "@icp-sdk/core":
-        specifier: ^5.0.0
-        version: 5.0.0
+        specifier: ^5.2.1
+        version: 5.2.1
       "@ledgerhq/hw-transport-node-hid-noevents":
         specifier: ^6.34.0
         version: 6.34.0
@@ -109,7 +109,7 @@ importers:
         specifier: ^6.34.0
         version: 6.34.0
       "@zondax/ledger-icp":
-        specifier: ^3.2.6
+        specifier: ^3.2.8
         version: 3.2.8
       node-hid:
         specifier: ^3.2.0
@@ -395,10 +395,10 @@ packages:
       "@dfinity/utils": ^4.1
       "@icp-sdk/core": ^5
 
-  "@icp-sdk/core@5.0.0":
+  "@icp-sdk/core@5.2.1":
     resolution:
       {
-        integrity: sha512-t6iRbdylHG57MicWRpR1uMTFXRW7GCzec6KAg55CBwDHbHLQDKikQ252lmlcEa80DrKa3LPvMKYZEUYjEq5XUQ==,
+        integrity: sha512-FImRjnayCarov7vfr52QU3BO8tPAprbyl4O+0KWz4v7h8ZbKq15fhtdb53M6+ltUsCbWkP/lEgrQ4t1WhIAHjQ==,
       }
 
   "@jridgewell/resolve-uri@3.1.2":
@@ -1771,13 +1771,13 @@ snapshots:
 
   "@dfinity/pic@0.21.0":
     dependencies:
-      "@icp-sdk/core": 5.0.0
+      "@icp-sdk/core": 5.2.1
       bip39: 3.1.0
       json-with-bigint: 3.5.7
 
-  "@dfinity/utils@4.1.0(@icp-sdk/core@5.0.0)":
+  "@dfinity/utils@4.1.0(@icp-sdk/core@5.2.1)":
     dependencies:
-      "@icp-sdk/core": 5.0.0
+      "@icp-sdk/core": 5.2.1
 
   "@emnapi/core@1.9.1":
     dependencies:
@@ -1870,16 +1870,16 @@ snapshots:
   "@esbuild/win32-x64@0.25.0":
     optional: true
 
-  "@icp-sdk/canisters@3.4.0(@dfinity/utils@4.1.0(@icp-sdk/core@5.0.0))(@icp-sdk/core@5.0.0)":
+  "@icp-sdk/canisters@3.4.0(@dfinity/utils@4.1.0(@icp-sdk/core@5.2.1))(@icp-sdk/core@5.2.1)":
     dependencies:
-      "@dfinity/utils": 4.1.0(@icp-sdk/core@5.0.0)
-      "@icp-sdk/core": 5.0.0
+      "@dfinity/utils": 4.1.0(@icp-sdk/core@5.2.1)
+      "@icp-sdk/core": 5.2.1
       "@noble/hashes": 1.8.0
       base58-js: 3.0.3
       bech32: 2.0.0
       mime: 3.0.0
 
-  "@icp-sdk/core@5.0.0":
+  "@icp-sdk/core@5.2.1":
     dependencies:
       "@dfinity/cbor": 0.2.2
       "@noble/curves": 1.9.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,7 +66,7 @@ importers:
         specifier: ^5.2.1
         version: 5.2.1
       "@zondax/ledger-icp":
-        specifier: ^3.2.6
+        specifier: ^3.2.8
         version: 3.2.8
       chalk:
         specifier: ^4.1.2


### PR DESCRIPTION
  - Upgrade @icp-sdk/core from ^5.0.0 to ^5.2.1 across all packages
  - Upgrade @zondax/ledger-icp from ^3.2.6 to ^3.2.8
  - Add update() method to Icrc21Agent (required by new Agent interface)
  - Refactor Icrc21Agent to use update() internally, removing manual certificateLookup and checkForRejection
  - Simplify CLI's icrc21Call to use agent.update() instead of manual certificate parsing
  - Add tests for update(): success with decoded reply, ICRC-21 errors, and canister rejection