### PR TITLE
ci: add checks-pass aggregator job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,24 @@ jobs:
           sudo apt-get install -y libusb-1.0-0-dev libudev-dev
       - run: pnpm install
       - run: pnpm test
+
+  # Single aggregator status check. Configure GitHub branch protection
+  # to require `checks-pass` so that any failing, cancelled, or skipped
+  # upstream job blocks the merge, without having to enumerate every
+  # individual job in the ruleset.
+  checks-pass:
+    # Always run this job!
+    if: always()
+    needs:
+      [
+        build,
+        typecheck,
+        format,
+        test,
+      ]
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}" == "true" ]]; then
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,13 +55,7 @@ jobs:
   checks-pass:
     # Always run this job!
     if: always()
-    needs:
-      [
-        build,
-        typecheck,
-        format,
-        test,
-      ]
+    needs: [build, typecheck, format, test]
     runs-on: ubuntu-latest
     steps:
       - run: |


### PR DESCRIPTION
## Summary

Add a single `checks-pass` aggregator status check that depends on every quality-gate job and fails if any upstream job is non-success (failure, cancelled, or skipped).

This lets GitHub branch protection / rulesets gate merges on a single context name (`checks-pass`) instead of enumerating every individual job. It also future-proofs the protection rule: adding or removing a CI job only needs an update to the `needs:` list here.

Mirrors the pattern already in use in `dfinity/dogecoin-canister` and `dfinity/sol-rpc-canister`.

## Follow-up (admin action, not in this PR)

After this merges to `main`, an admin should add a `required_status_checks` rule listing `checks-pass` as a required context, so that future PRs can't merge with red CI.

Tracked via DEFI-2807.