### PR TITLE
chore: bump vite to 8.0.16 to resolve Dependabot alert #16

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "prettier": "^2.6.2",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0",
+    "vite": "^8.0.16",
     "vitest": "^4.1.2"
   },
   "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,9 +25,12 @@ importers:
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
+      vite:
+        specifier: ^8.0.16
+        version: 8.0.16(@types/node@17.0.45)
       vitest:
         specifier: ^4.1.2
-        version: 4.1.4(@types/node@17.0.45)(vite@8.0.9(@types/node@17.0.45))
+        version: 4.1.4(@types/node@17.0.45)(vite@8.0.16(@types/node@17.0.45))
 
   examples/icrc21-swap:
     dependencies:
@@ -143,16 +146,16 @@ packages:
     peerDependencies:
       "@icp-sdk/core": ^5
 
-  "@emnapi/core@1.9.2":
+  "@emnapi/core@1.10.0":
     resolution:
       {
-        integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==,
+        integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==,
       }
 
-  "@emnapi/runtime@1.9.2":
+  "@emnapi/runtime@1.10.0":
     resolution:
       {
-        integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==,
+        integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==,
       }
 
   "@emnapi/wasi-threads@1.2.1":
@@ -485,150 +488,150 @@ packages:
       }
     engines: { node: ^14.21.3 || >=16 }
 
-  "@oxc-project/types@0.126.0":
+  "@oxc-project/types@0.133.0":
     resolution:
       {
-        integrity: sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==,
+        integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==,
       }
 
-  "@rolldown/binding-android-arm64@1.0.0-rc.16":
+  "@rolldown/binding-android-arm64@1.0.3":
     resolution:
       {
-        integrity: sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==,
+        integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [android]
 
-  "@rolldown/binding-darwin-arm64@1.0.0-rc.16":
+  "@rolldown/binding-darwin-arm64@1.0.3":
     resolution:
       {
-        integrity: sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==,
+        integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [darwin]
 
-  "@rolldown/binding-darwin-x64@1.0.0-rc.16":
+  "@rolldown/binding-darwin-x64@1.0.3":
     resolution:
       {
-        integrity: sha512-r/OmdR00HmD4i79Z//xO06uEPOq5hRXdhw7nzkxQxwSavs3PSHa1ijntdpOiZ2mzOQ3fVVu8C1M19FoNM+dMUQ==,
+        integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [darwin]
 
-  "@rolldown/binding-freebsd-x64@1.0.0-rc.16":
+  "@rolldown/binding-freebsd-x64@1.0.3":
     resolution:
       {
-        integrity: sha512-KcRE5w8h0OnjUatG8pldyD14/CQ5Phs1oxfR+3pKDjboHRo9+MkqQaiIZlZRpsxC15paeXme/I127tUa9TXJ6g==,
+        integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [freebsd]
 
-  "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.16":
+  "@rolldown/binding-linux-arm-gnueabihf@1.0.3":
     resolution:
       {
-        integrity: sha512-bT0guA1bpxEJ/ZhTRniQf7rNF8ybvXOuWbNIeLABaV5NGjx4EtOWBTSRGWFU9ZWVkPOZ+HNFP8RMcBokBiZ0Kg==,
+        integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm]
     os: [linux]
 
-  "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.16":
+  "@rolldown/binding-linux-arm64-gnu@1.0.3":
     resolution:
       {
-        integrity: sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==,
+        integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
 
-  "@rolldown/binding-linux-arm64-musl@1.0.0-rc.16":
+  "@rolldown/binding-linux-arm64-musl@1.0.3":
     resolution:
       {
-        integrity: sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==,
+        integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
 
-  "@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.16":
+  "@rolldown/binding-linux-ppc64-gnu@1.0.3":
     resolution:
       {
-        integrity: sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==,
+        integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [ppc64]
     os: [linux]
 
-  "@rolldown/binding-linux-s390x-gnu@1.0.0-rc.16":
+  "@rolldown/binding-linux-s390x-gnu@1.0.3":
     resolution:
       {
-        integrity: sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==,
+        integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [s390x]
     os: [linux]
 
-  "@rolldown/binding-linux-x64-gnu@1.0.0-rc.16":
+  "@rolldown/binding-linux-x64-gnu@1.0.3":
     resolution:
       {
-        integrity: sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==,
+        integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
 
-  "@rolldown/binding-linux-x64-musl@1.0.0-rc.16":
+  "@rolldown/binding-linux-x64-musl@1.0.3":
     resolution:
       {
-        integrity: sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==,
+        integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
 
-  "@rolldown/binding-openharmony-arm64@1.0.0-rc.16":
+  "@rolldown/binding-openharmony-arm64@1.0.3":
     resolution:
       {
-        integrity: sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==,
+        integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [openharmony]
 
-  "@rolldown/binding-wasm32-wasi@1.0.0-rc.16":
+  "@rolldown/binding-wasm32-wasi@1.0.3":
     resolution:
       {
-        integrity: sha512-3Q2KQxnC8IJOLqXmUMoYwyIPZU9hzRbnHaoV3Euz+VVnjZKcY8ktnNP8T9R4/GGQtb27C/UYKABxesKWb8lsvQ==,
+        integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [wasm32]
 
-  "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.16":
+  "@rolldown/binding-win32-arm64-msvc@1.0.3":
     resolution:
       {
-        integrity: sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==,
+        integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [win32]
 
-  "@rolldown/binding-win32-x64-msvc@1.0.0-rc.16":
+  "@rolldown/binding-win32-x64-msvc@1.0.3":
     resolution:
       {
-        integrity: sha512-PH5DRZT+F4f2PTXRXR8uJxnBq2po/xFtddyabTJVJs/ZYVHqXPEgNIr35IHTEa6bpa0Q8Awg+ymkTaGnKITw4g==,
+        integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [win32]
 
-  "@rolldown/pluginutils@1.0.0-rc.16":
+  "@rolldown/pluginutils@1.0.1":
     resolution:
       {
-        integrity: sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==,
+        integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==,
       }
 
   "@scure/base@1.2.6":
@@ -1256,10 +1259,10 @@ packages:
         integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==,
       }
 
-  nanoid@3.3.11:
+  nanoid@3.3.12:
     resolution:
       {
-        integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==,
+        integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==,
       }
     engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
@@ -1344,10 +1347,10 @@ packages:
     engines: { node: ">= 14.15.0" }
     hasBin: true
 
-  postcss@8.5.10:
+  postcss@8.5.15:
     resolution:
       {
-        integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==,
+        integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==,
       }
     engines: { node: ^10 || ^12 || >=14 }
 
@@ -1408,10 +1411,10 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
-  rolldown@1.0.0-rc.16:
+  rolldown@1.0.3:
     resolution:
       {
-        integrity: sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==,
+        integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
@@ -1548,6 +1551,13 @@ packages:
       }
     engines: { node: ">=12.0.0" }
 
+  tinyglobby@0.2.17:
+    resolution:
+      {
+        integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==,
+      }
+    engines: { node: ">=12.0.0" }
+
   tinyrainbow@3.1.0:
     resolution:
       {
@@ -1604,16 +1614,16 @@ packages:
         integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==,
       }
 
-  vite@8.0.9:
+  vite@8.0.16:
     resolution:
       {
-        integrity: sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==,
+        integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
     peerDependencies:
       "@types/node": ^20.19.0 || >=22.12.0
-      "@vitejs/devtools": ^0.1.0
+      "@vitejs/devtools": ^0.1.18
       esbuild: ^0.27.0 || ^0.28.0
       jiti: ">=1.21.0"
       less: ^4.0.0
@@ -1775,13 +1785,13 @@ snapshots:
     dependencies:
       "@icp-sdk/core": 5.3.0
 
-  "@emnapi/core@1.9.2":
+  "@emnapi/core@1.10.0":
     dependencies:
       "@emnapi/wasi-threads": 1.2.1
       tslib: 2.8.1
     optional: true
 
-  "@emnapi/runtime@1.9.2":
+  "@emnapi/runtime@1.10.0":
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -1932,10 +1942,10 @@ snapshots:
 
   "@ledgerhq/logs@6.17.0": {}
 
-  "@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)":
+  "@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)":
     dependencies:
-      "@emnapi/core": 1.9.2
-      "@emnapi/runtime": 1.9.2
+      "@emnapi/core": 1.10.0
+      "@emnapi/runtime": 1.10.0
       "@tybys/wasm-util": 0.10.1
     optional: true
 
@@ -1945,58 +1955,58 @@ snapshots:
 
   "@noble/hashes@1.8.0": {}
 
-  "@oxc-project/types@0.126.0": {}
+  "@oxc-project/types@0.133.0": {}
 
-  "@rolldown/binding-android-arm64@1.0.0-rc.16":
+  "@rolldown/binding-android-arm64@1.0.3":
     optional: true
 
-  "@rolldown/binding-darwin-arm64@1.0.0-rc.16":
+  "@rolldown/binding-darwin-arm64@1.0.3":
     optional: true
 
-  "@rolldown/binding-darwin-x64@1.0.0-rc.16":
+  "@rolldown/binding-darwin-x64@1.0.3":
     optional: true
 
-  "@rolldown/binding-freebsd-x64@1.0.0-rc.16":
+  "@rolldown/binding-freebsd-x64@1.0.3":
     optional: true
 
-  "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.16":
+  "@rolldown/binding-linux-arm-gnueabihf@1.0.3":
     optional: true
 
-  "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.16":
+  "@rolldown/binding-linux-arm64-gnu@1.0.3":
     optional: true
 
-  "@rolldown/binding-linux-arm64-musl@1.0.0-rc.16":
+  "@rolldown/binding-linux-arm64-musl@1.0.3":
     optional: true
 
-  "@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.16":
+  "@rolldown/binding-linux-ppc64-gnu@1.0.3":
     optional: true
 
-  "@rolldown/binding-linux-s390x-gnu@1.0.0-rc.16":
+  "@rolldown/binding-linux-s390x-gnu@1.0.3":
     optional: true
 
-  "@rolldown/binding-linux-x64-gnu@1.0.0-rc.16":
+  "@rolldown/binding-linux-x64-gnu@1.0.3":
     optional: true
 
-  "@rolldown/binding-linux-x64-musl@1.0.0-rc.16":
+  "@rolldown/binding-linux-x64-musl@1.0.3":
     optional: true
 
-  "@rolldown/binding-openharmony-arm64@1.0.0-rc.16":
+  "@rolldown/binding-openharmony-arm64@1.0.3":
     optional: true
 
-  "@rolldown/binding-wasm32-wasi@1.0.0-rc.16":
+  "@rolldown/binding-wasm32-wasi@1.0.3":
     dependencies:
-      "@emnapi/core": 1.9.2
-      "@emnapi/runtime": 1.9.2
-      "@napi-rs/wasm-runtime": 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      "@emnapi/core": 1.10.0
+      "@emnapi/runtime": 1.10.0
+      "@napi-rs/wasm-runtime": 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.16":
+  "@rolldown/binding-win32-arm64-msvc@1.0.3":
     optional: true
 
-  "@rolldown/binding-win32-x64-msvc@1.0.0-rc.16":
+  "@rolldown/binding-win32-x64-msvc@1.0.3":
     optional: true
 
-  "@rolldown/pluginutils@1.0.0-rc.16": {}
+  "@rolldown/pluginutils@1.0.1": {}
 
   "@scure/base@1.2.6": {}
 
@@ -2052,13 +2062,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  "@vitest/mocker@4.1.4(vite@8.0.9(@types/node@17.0.45))":
+  "@vitest/mocker@4.1.4(vite@8.0.16(@types/node@17.0.45))":
     dependencies:
       "@vitest/spy": 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.9(@types/node@17.0.45)
+      vite: 8.0.16(@types/node@17.0.45)
 
   "@vitest/pretty-format@4.1.4":
     dependencies:
@@ -2319,7 +2329,7 @@ snapshots:
 
   mkdirp-classic@0.5.3: {}
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.12: {}
 
   napi-build-utils@2.0.0: {}
 
@@ -2363,9 +2373,9 @@ snapshots:
     dependencies:
       yargs: 17.7.2
 
-  postcss@8.5.10:
+  postcss@8.5.15:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -2412,26 +2422,26 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  rolldown@1.0.0-rc.16:
+  rolldown@1.0.3:
     dependencies:
-      "@oxc-project/types": 0.126.0
-      "@rolldown/pluginutils": 1.0.0-rc.16
+      "@oxc-project/types": 0.133.0
+      "@rolldown/pluginutils": 1.0.1
     optionalDependencies:
-      "@rolldown/binding-android-arm64": 1.0.0-rc.16
-      "@rolldown/binding-darwin-arm64": 1.0.0-rc.16
-      "@rolldown/binding-darwin-x64": 1.0.0-rc.16
-      "@rolldown/binding-freebsd-x64": 1.0.0-rc.16
-      "@rolldown/binding-linux-arm-gnueabihf": 1.0.0-rc.16
-      "@rolldown/binding-linux-arm64-gnu": 1.0.0-rc.16
-      "@rolldown/binding-linux-arm64-musl": 1.0.0-rc.16
-      "@rolldown/binding-linux-ppc64-gnu": 1.0.0-rc.16
-      "@rolldown/binding-linux-s390x-gnu": 1.0.0-rc.16
-      "@rolldown/binding-linux-x64-gnu": 1.0.0-rc.16
-      "@rolldown/binding-linux-x64-musl": 1.0.0-rc.16
-      "@rolldown/binding-openharmony-arm64": 1.0.0-rc.16
-      "@rolldown/binding-wasm32-wasi": 1.0.0-rc.16
-      "@rolldown/binding-win32-arm64-msvc": 1.0.0-rc.16
-      "@rolldown/binding-win32-x64-msvc": 1.0.0-rc.16
+      "@rolldown/binding-android-arm64": 1.0.3
+      "@rolldown/binding-darwin-arm64": 1.0.3
+      "@rolldown/binding-darwin-x64": 1.0.3
+      "@rolldown/binding-freebsd-x64": 1.0.3
+      "@rolldown/binding-linux-arm-gnueabihf": 1.0.3
+      "@rolldown/binding-linux-arm64-gnu": 1.0.3
+      "@rolldown/binding-linux-arm64-musl": 1.0.3
+      "@rolldown/binding-linux-ppc64-gnu": 1.0.3
+      "@rolldown/binding-linux-s390x-gnu": 1.0.3
+      "@rolldown/binding-linux-x64-gnu": 1.0.3
+      "@rolldown/binding-linux-x64-musl": 1.0.3
+      "@rolldown/binding-openharmony-arm64": 1.0.3
+      "@rolldown/binding-wasm32-wasi": 1.0.3
+      "@rolldown/binding-win32-arm64-msvc": 1.0.3
+      "@rolldown/binding-win32-x64-msvc": 1.0.3
 
   rxjs@7.8.2:
     dependencies:
@@ -2503,6 +2513,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tinyrainbow@3.1.0: {}
 
   ts-node@10.9.2(@types/node@17.0.45)(typescript@5.9.3):
@@ -2535,21 +2550,21 @@ snapshots:
 
   v8-compile-cache-lib@3.0.1: {}
 
-  vite@8.0.9(@types/node@17.0.45):
+  vite@8.0.16(@types/node@17.0.45):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.10
-      rolldown: 1.0.0-rc.16
-      tinyglobby: 0.2.16
+      postcss: 8.5.15
+      rolldown: 1.0.3
+      tinyglobby: 0.2.17
     optionalDependencies:
       "@types/node": 17.0.45
       fsevents: 2.3.3
 
-  vitest@4.1.4(@types/node@17.0.45)(vite@8.0.9(@types/node@17.0.45)):
+  vitest@4.1.4(@types/node@17.0.45)(vite@8.0.16(@types/node@17.0.45)):
     dependencies:
       "@vitest/expect": 4.1.4
-      "@vitest/mocker": 4.1.4(vite@8.0.9(@types/node@17.0.45))
+      "@vitest/mocker": 4.1.4(vite@8.0.16(@types/node@17.0.45))
       "@vitest/pretty-format": 4.1.4
       "@vitest/runner": 4.1.4
       "@vitest/snapshot": 4.1.4
@@ -2566,7 +2581,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.9(@types/node@17.0.45)
+      vite: 8.0.16(@types/node@17.0.45)
       why-is-node-running: 2.3.0
     optionalDependencies:
       "@types/node": 17.0.45


### PR DESCRIPTION
## Summary

Resolves Dependabot alert [#16](https://github.com/dfinity/hardware-wallet-cli/security/dependabot/16) — the high-severity `vite` advisory **GHSA-fx2h-pf6j-xcff / CVE-2026-53571** (`server.fs.deny` bypass on Windows alternate paths). Affects `vite >= 8.0.0, <= 8.0.15`; we were on `8.0.9`.

`vite` is a dev-only, transitive dependency (pulled in by `vitest`) and the vulnerable Vite dev-server code path is never exercised by this CLI, so this is a hygiene bump to clear the alert rather than a production-affecting fix.

## Change

- Add an explicit `vite` devDependency pinned at `^8.0.16`, bumping the resolved version `8.0.9 → 8.0.16`.

A plain `overrides` entry was not enough: `vite` is an *auto-installed peer* of `vitest`, so the override only updated the peer requirement while the resolved version stayed at `8.0.9`. Declaring `vite` directly forces the patched version.

The lockfile changes are confined to vite and its bundler subtree (`@rolldown/*`, `@oxc-project/types`, `@emnapi/*`, and the `@vitest/mocker` peer reference). No other dependencies change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)