### PR TITLE
chore: bump esbuild to 0.28.1 to resolve Dependabot alerts #12-#14

### DIFF
--- a/examples/icrc21-swap/package.json
+++ b/examples/icrc21-swap/package.json
@@ -13,6 +13,6 @@
   },
   "devDependencies": {
     "buffer": "^6.0.3",
-    "esbuild": "0.25.0"
+    "esbuild": "0.28.1"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@types/node": "^17.0.16",
     "@types/node-hid": "^1.3.1",
-    "esbuild": "0.25.0"
+    "esbuild": "0.28.1"
   },
   "license": "ISC"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.2
-        version: 4.1.4(@types/node@17.0.45)(vite@8.0.9(@types/node@17.0.45))
+        version: 4.1.4(@types/node@17.0.45)(vite@8.0.9(@types/node@17.0.45)(esbuild@0.28.1))
 
   examples/icrc21-swap:
     dependencies:
@@ -45,8 +45,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       esbuild:
-        specifier: 0.25.0
-        version: 0.25.0
+        specifier: 0.28.1
+        version: 0.28.1
 
   packages/cli:
     dependencies:
@@ -88,8 +88,8 @@ importers:
         specifier: ^1.3.1
         version: 1.3.4
       esbuild:
-        specifier: 0.25.0
-        version: 0.25.0
+        specifier: 0.28.1
+        version: 0.28.1
 
   packages/icrc21-agent:
     dependencies:
@@ -161,226 +161,235 @@ packages:
         integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==,
       }
 
-  "@esbuild/aix-ppc64@0.25.0":
+  "@esbuild/aix-ppc64@0.28.1":
     resolution:
       {
-        integrity: sha512-O7vun9Sf8DFjH2UtqK8Ku3LkquL9SZL8OLY1T5NZkA34+wG3OQF7cl4Ql8vdNzM6fzBbYfLaiRLIOZ+2FOCgBQ==,
+        integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==,
       }
     engines: { node: ">=18" }
     cpu: [ppc64]
     os: [aix]
 
-  "@esbuild/android-arm64@0.25.0":
+  "@esbuild/android-arm64@0.28.1":
     resolution:
       {
-        integrity: sha512-grvv8WncGjDSyUBjN9yHXNt+cq0snxXbDxy5pJtzMKGmmpPxeAmAhWxXI+01lU5rwZomDgD3kJwulEnhTRUd6g==,
+        integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [android]
 
-  "@esbuild/android-arm@0.25.0":
+  "@esbuild/android-arm@0.28.1":
     resolution:
       {
-        integrity: sha512-PTyWCYYiU0+1eJKmw21lWtC+d08JDZPQ5g+kFyxP0V+es6VPPSUhM6zk8iImp2jbV6GwjX4pap0JFbUQN65X1g==,
+        integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==,
       }
     engines: { node: ">=18" }
     cpu: [arm]
     os: [android]
 
-  "@esbuild/android-x64@0.25.0":
+  "@esbuild/android-x64@0.28.1":
     resolution:
       {
-        integrity: sha512-m/ix7SfKG5buCnxasr52+LI78SQ+wgdENi9CqyCXwjVR2X4Jkz+BpC3le3AoBPYTC9NHklwngVXvbJ9/Akhrfg==,
+        integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
     os: [android]
 
-  "@esbuild/darwin-arm64@0.25.0":
+  "@esbuild/darwin-arm64@0.28.1":
     resolution:
       {
-        integrity: sha512-mVwdUb5SRkPayVadIOI78K7aAnPamoeFR2bT5nszFUZ9P8UpK4ratOdYbZZXYSqPKMHfS1wdHCJk1P1EZpRdvw==,
+        integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [darwin]
 
-  "@esbuild/darwin-x64@0.25.0":
+  "@esbuild/darwin-x64@0.28.1":
     resolution:
       {
-        integrity: sha512-DgDaYsPWFTS4S3nWpFcMn/33ZZwAAeAFKNHNa1QN0rI4pUjgqf0f7ONmXf6d22tqTY+H9FNdgeaAa+YIFUn2Rg==,
+        integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
     os: [darwin]
 
-  "@esbuild/freebsd-arm64@0.25.0":
+  "@esbuild/freebsd-arm64@0.28.1":
     resolution:
       {
-        integrity: sha512-VN4ocxy6dxefN1MepBx/iD1dH5K8qNtNe227I0mnTRjry8tj5MRk4zprLEdG8WPyAPb93/e4pSgi1SoHdgOa4w==,
+        integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [freebsd]
 
-  "@esbuild/freebsd-x64@0.25.0":
+  "@esbuild/freebsd-x64@0.28.1":
     resolution:
       {
-        integrity: sha512-mrSgt7lCh07FY+hDD1TxiTyIHyttn6vnjesnPoVDNmDfOmggTLXRv8Id5fNZey1gl/V2dyVK1VXXqVsQIiAk+A==,
+        integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
     os: [freebsd]
 
-  "@esbuild/linux-arm64@0.25.0":
+  "@esbuild/linux-arm64@0.28.1":
     resolution:
       {
-        integrity: sha512-9QAQjTWNDM/Vk2bgBl17yWuZxZNQIF0OUUuPZRKoDtqF2k4EtYbpyiG5/Dk7nqeK6kIJWPYldkOcBqjXjrUlmg==,
+        integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [linux]
 
-  "@esbuild/linux-arm@0.25.0":
+  "@esbuild/linux-arm@0.28.1":
     resolution:
       {
-        integrity: sha512-vkB3IYj2IDo3g9xX7HqhPYxVkNQe8qTK55fraQyTzTX/fxaDtXiEnavv9geOsonh2Fd2RMB+i5cbhu2zMNWJwg==,
+        integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==,
       }
     engines: { node: ">=18" }
     cpu: [arm]
     os: [linux]
 
-  "@esbuild/linux-ia32@0.25.0":
+  "@esbuild/linux-ia32@0.28.1":
     resolution:
       {
-        integrity: sha512-43ET5bHbphBegyeqLb7I1eYn2P/JYGNmzzdidq/w0T8E2SsYL1U6un2NFROFRg1JZLTzdCoRomg8Rvf9M6W6Gg==,
+        integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==,
       }
     engines: { node: ">=18" }
     cpu: [ia32]
     os: [linux]
 
-  "@esbuild/linux-loong64@0.25.0":
+  "@esbuild/linux-loong64@0.28.1":
     resolution:
       {
-        integrity: sha512-fC95c/xyNFueMhClxJmeRIj2yrSMdDfmqJnyOY4ZqsALkDrrKJfIg5NTMSzVBr5YW1jf+l7/cndBfP3MSDpoHw==,
+        integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==,
       }
     engines: { node: ">=18" }
     cpu: [loong64]
     os: [linux]
 
-  "@esbuild/linux-mips64el@0.25.0":
+  "@esbuild/linux-mips64el@0.28.1":
     resolution:
       {
-        integrity: sha512-nkAMFju7KDW73T1DdH7glcyIptm95a7Le8irTQNO/qtkoyypZAnjchQgooFUDQhNAy4iu08N79W4T4pMBwhPwQ==,
+        integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==,
       }
     engines: { node: ">=18" }
     cpu: [mips64el]
     os: [linux]
 
-  "@esbuild/linux-ppc64@0.25.0":
+  "@esbuild/linux-ppc64@0.28.1":
     resolution:
       {
-        integrity: sha512-NhyOejdhRGS8Iwv+KKR2zTq2PpysF9XqY+Zk77vQHqNbo/PwZCzB5/h7VGuREZm1fixhs4Q/qWRSi5zmAiO4Fw==,
+        integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==,
       }
     engines: { node: ">=18" }
     cpu: [ppc64]
     os: [linux]
 
-  "@esbuild/linux-riscv64@0.25.0":
+  "@esbuild/linux-riscv64@0.28.1":
     resolution:
       {
-        integrity: sha512-5S/rbP5OY+GHLC5qXp1y/Mx//e92L1YDqkiBbO9TQOvuFXM+iDqUNG5XopAnXoRH3FjIUDkeGcY1cgNvnXp/kA==,
+        integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==,
       }
     engines: { node: ">=18" }
     cpu: [riscv64]
     os: [linux]
 
-  "@esbuild/linux-s390x@0.25.0":
+  "@esbuild/linux-s390x@0.28.1":
     resolution:
       {
-        integrity: sha512-XM2BFsEBz0Fw37V0zU4CXfcfuACMrppsMFKdYY2WuTS3yi8O1nFOhil/xhKTmE1nPmVyvQJjJivgDT+xh8pXJA==,
+        integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==,
       }
     engines: { node: ">=18" }
     cpu: [s390x]
     os: [linux]
 
-  "@esbuild/linux-x64@0.25.0":
+  "@esbuild/linux-x64@0.28.1":
     resolution:
       {
-        integrity: sha512-9yl91rHw/cpwMCNytUDxwj2XjFpxML0y9HAOH9pNVQDpQrBxHy01Dx+vaMu0N1CKa/RzBD2hB4u//nfc+Sd3Cw==,
+        integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
     os: [linux]
 
-  "@esbuild/netbsd-arm64@0.25.0":
+  "@esbuild/netbsd-arm64@0.28.1":
     resolution:
       {
-        integrity: sha512-RuG4PSMPFfrkH6UwCAqBzauBWTygTvb1nxWasEJooGSJ/NwRw7b2HOwyRTQIU97Hq37l3npXoZGYMy3b3xYvPw==,
+        integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [netbsd]
 
-  "@esbuild/netbsd-x64@0.25.0":
+  "@esbuild/netbsd-x64@0.28.1":
     resolution:
       {
-        integrity: sha512-jl+qisSB5jk01N5f7sPCsBENCOlPiS/xptD5yxOx2oqQfyourJwIKLRA2yqWdifj3owQZCL2sn6o08dBzZGQzA==,
+        integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
     os: [netbsd]
 
-  "@esbuild/openbsd-arm64@0.25.0":
+  "@esbuild/openbsd-arm64@0.28.1":
     resolution:
       {
-        integrity: sha512-21sUNbq2r84YE+SJDfaQRvdgznTD8Xc0oc3p3iW/a1EVWeNj/SdUCbm5U0itZPQYRuRTW20fPMWMpcrciH2EJw==,
+        integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [openbsd]
 
-  "@esbuild/openbsd-x64@0.25.0":
+  "@esbuild/openbsd-x64@0.28.1":
     resolution:
       {
-        integrity: sha512-2gwwriSMPcCFRlPlKx3zLQhfN/2WjJ2NSlg5TKLQOJdV0mSxIcYNTMhk3H3ulL/cak+Xj0lY1Ym9ysDV1igceg==,
+        integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
     os: [openbsd]
 
-  "@esbuild/sunos-x64@0.25.0":
+  "@esbuild/openharmony-arm64@0.28.1":
     resolution:
       {
-        integrity: sha512-bxI7ThgLzPrPz484/S9jLlvUAHYMzy6I0XiU1ZMeAEOBcS0VePBFxh1JjTQt3Xiat5b6Oh4x7UC7IwKQKIJRIg==,
+        integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [openharmony]
+
+  "@esbuild/sunos-x64@0.28.1":
+    resolution:
+      {
+        integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
     os: [sunos]
 
-  "@esbuild/win32-arm64@0.25.0":
+  "@esbuild/win32-arm64@0.28.1":
     resolution:
       {
-        integrity: sha512-ZUAc2YK6JW89xTbXvftxdnYy3m4iHIkDtK3CLce8wg8M2L+YZhIvO1DKpxrd0Yr59AeNNkTiic9YLf6FTtXWMw==,
+        integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [win32]
 
-  "@esbuild/win32-ia32@0.25.0":
+  "@esbuild/win32-ia32@0.28.1":
     resolution:
       {
-        integrity: sha512-eSNxISBu8XweVEWG31/JzjkIGbGIJN/TrRoiSVZwZ6pkC6VX4Im/WV2cz559/TXLcYbcrDN8JtKgd9DJVIo8GA==,
+        integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==,
       }
     engines: { node: ">=18" }
     cpu: [ia32]
     os: [win32]
 
-  "@esbuild/win32-x64@0.25.0":
+  "@esbuild/win32-x64@0.28.1":
     resolution:
       {
-        integrity: sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ==,
+        integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
@@ -986,10 +995,10 @@ packages:
         integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==,
       }
 
-  esbuild@0.25.0:
+  esbuild@0.28.1:
     resolution:
       {
-        integrity: sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==,
+        integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==,
       }
     engines: { node: ">=18" }
     hasBin: true
@@ -1791,79 +1800,82 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  "@esbuild/aix-ppc64@0.25.0":
+  "@esbuild/aix-ppc64@0.28.1":
     optional: true
 
-  "@esbuild/android-arm64@0.25.0":
+  "@esbuild/android-arm64@0.28.1":
     optional: true
 
-  "@esbuild/android-arm@0.25.0":
+  "@esbuild/android-arm@0.28.1":
     optional: true
 
-  "@esbuild/android-x64@0.25.0":
+  "@esbuild/android-x64@0.28.1":
     optional: true
 
-  "@esbuild/darwin-arm64@0.25.0":
+  "@esbuild/darwin-arm64@0.28.1":
     optional: true
 
-  "@esbuild/darwin-x64@0.25.0":
+  "@esbuild/darwin-x64@0.28.1":
     optional: true
 
-  "@esbuild/freebsd-arm64@0.25.0":
+  "@esbuild/freebsd-arm64@0.28.1":
     optional: true
 
-  "@esbuild/freebsd-x64@0.25.0":
+  "@esbuild/freebsd-x64@0.28.1":
     optional: true
 
-  "@esbuild/linux-arm64@0.25.0":
+  "@esbuild/linux-arm64@0.28.1":
     optional: true
 
-  "@esbuild/linux-arm@0.25.0":
+  "@esbuild/linux-arm@0.28.1":
     optional: true
 
-  "@esbuild/linux-ia32@0.25.0":
+  "@esbuild/linux-ia32@0.28.1":
     optional: true
 
-  "@esbuild/linux-loong64@0.25.0":
+  "@esbuild/linux-loong64@0.28.1":
     optional: true
 
-  "@esbuild/linux-mips64el@0.25.0":
+  "@esbuild/linux-mips64el@0.28.1":
     optional: true
 
-  "@esbuild/linux-ppc64@0.25.0":
+  "@esbuild/linux-ppc64@0.28.1":
     optional: true
 
-  "@esbuild/linux-riscv64@0.25.0":
+  "@esbuild/linux-riscv64@0.28.1":
     optional: true
 
-  "@esbuild/linux-s390x@0.25.0":
+  "@esbuild/linux-s390x@0.28.1":
     optional: true
 
-  "@esbuild/linux-x64@0.25.0":
+  "@esbuild/linux-x64@0.28.1":
     optional: true
 
-  "@esbuild/netbsd-arm64@0.25.0":
+  "@esbuild/netbsd-arm64@0.28.1":
     optional: true
 
-  "@esbuild/netbsd-x64@0.25.0":
+  "@esbuild/netbsd-x64@0.28.1":
     optional: true
 
-  "@esbuild/openbsd-arm64@0.25.0":
+  "@esbuild/openbsd-arm64@0.28.1":
     optional: true
 
-  "@esbuild/openbsd-x64@0.25.0":
+  "@esbuild/openbsd-x64@0.28.1":
     optional: true
 
-  "@esbuild/sunos-x64@0.25.0":
+  "@esbuild/openharmony-arm64@0.28.1":
     optional: true
 
-  "@esbuild/win32-arm64@0.25.0":
+  "@esbuild/sunos-x64@0.28.1":
     optional: true
 
-  "@esbuild/win32-ia32@0.25.0":
+  "@esbuild/win32-arm64@0.28.1":
     optional: true
 
-  "@esbuild/win32-x64@0.25.0":
+  "@esbuild/win32-ia32@0.28.1":
+    optional: true
+
+  "@esbuild/win32-x64@0.28.1":
     optional: true
 
   "@icp-sdk/canisters@3.5.2(@dfinity/utils@4.2.1(@icp-sdk/core@5.3.0))(@icp-sdk/core@5.3.0)":
@@ -2052,13 +2064,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  "@vitest/mocker@4.1.4(vite@8.0.9(@types/node@17.0.45))":
+  "@vitest/mocker@4.1.4(vite@8.0.9(@types/node@17.0.45)(esbuild@0.28.1))":
     dependencies:
       "@vitest/spy": 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.9(@types/node@17.0.45)
+      vite: 8.0.9(@types/node@17.0.45)(esbuild@0.28.1)
 
   "@vitest/pretty-format@4.1.4":
     dependencies:
@@ -2189,33 +2201,34 @@ snapshots:
 
   es-module-lexer@2.0.0: {}
 
-  esbuild@0.25.0:
+  esbuild@0.28.1:
     optionalDependencies:
-      "@esbuild/aix-ppc64": 0.25.0
-      "@esbuild/android-arm": 0.25.0
-      "@esbuild/android-arm64": 0.25.0
-      "@esbuild/android-x64": 0.25.0
-      "@esbuild/darwin-arm64": 0.25.0
-      "@esbuild/darwin-x64": 0.25.0
-      "@esbuild/freebsd-arm64": 0.25.0
-      "@esbuild/freebsd-x64": 0.25.0
-      "@esbuild/linux-arm": 0.25.0
-      "@esbuild/linux-arm64": 0.25.0
-      "@esbuild/linux-ia32": 0.25.0
-      "@esbuild/linux-loong64": 0.25.0
-      "@esbuild/linux-mips64el": 0.25.0
-      "@esbuild/linux-ppc64": 0.25.0
-      "@esbuild/linux-riscv64": 0.25.0
-      "@esbuild/linux-s390x": 0.25.0
-      "@esbuild/linux-x64": 0.25.0
-      "@esbuild/netbsd-arm64": 0.25.0
-      "@esbuild/netbsd-x64": 0.25.0
-      "@esbuild/openbsd-arm64": 0.25.0
-      "@esbuild/openbsd-x64": 0.25.0
-      "@esbuild/sunos-x64": 0.25.0
-      "@esbuild/win32-arm64": 0.25.0
-      "@esbuild/win32-ia32": 0.25.0
-      "@esbuild/win32-x64": 0.25.0
+      "@esbuild/aix-ppc64": 0.28.1
+      "@esbuild/android-arm": 0.28.1
+      "@esbuild/android-arm64": 0.28.1
+      "@esbuild/android-x64": 0.28.1
+      "@esbuild/darwin-arm64": 0.28.1
+      "@esbuild/darwin-x64": 0.28.1
+      "@esbuild/freebsd-arm64": 0.28.1
+      "@esbuild/freebsd-x64": 0.28.1
+      "@esbuild/linux-arm": 0.28.1
+      "@esbuild/linux-arm64": 0.28.1
+      "@esbuild/linux-ia32": 0.28.1
+      "@esbuild/linux-loong64": 0.28.1
+      "@esbuild/linux-mips64el": 0.28.1
+      "@esbuild/linux-ppc64": 0.28.1
+      "@esbuild/linux-riscv64": 0.28.1
+      "@esbuild/linux-s390x": 0.28.1
+      "@esbuild/linux-x64": 0.28.1
+      "@esbuild/netbsd-arm64": 0.28.1
+      "@esbuild/netbsd-x64": 0.28.1
+      "@esbuild/openbsd-arm64": 0.28.1
+      "@esbuild/openbsd-x64": 0.28.1
+      "@esbuild/openharmony-arm64": 0.28.1
+      "@esbuild/sunos-x64": 0.28.1
+      "@esbuild/win32-arm64": 0.28.1
+      "@esbuild/win32-ia32": 0.28.1
+      "@esbuild/win32-x64": 0.28.1
 
   escalade@3.2.0: {}
 
@@ -2535,7 +2548,7 @@ snapshots:
 
   v8-compile-cache-lib@3.0.1: {}
 
-  vite@8.0.9(@types/node@17.0.45):
+  vite@8.0.9(@types/node@17.0.45)(esbuild@0.28.1):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -2544,12 +2557,13 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       "@types/node": 17.0.45
+      esbuild: 0.28.1
       fsevents: 2.3.3
 
-  vitest@4.1.4(@types/node@17.0.45)(vite@8.0.9(@types/node@17.0.45)):
+  vitest@4.1.4(@types/node@17.0.45)(vite@8.0.9(@types/node@17.0.45)(esbuild@0.28.1)):
     dependencies:
       "@vitest/expect": 4.1.4
-      "@vitest/mocker": 4.1.4(vite@8.0.9(@types/node@17.0.45))
+      "@vitest/mocker": 4.1.4(vite@8.0.9(@types/node@17.0.45)(esbuild@0.28.1))
       "@vitest/pretty-format": 4.1.4
       "@vitest/runner": 4.1.4
       "@vitest/snapshot": 4.1.4
@@ -2566,7 +2580,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.9(@types/node@17.0.45)
+      vite: 8.0.9(@types/node@17.0.45)(esbuild@0.28.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       "@types/node": 17.0.45


### PR DESCRIPTION
## Summary

Resolves Dependabot alerts [#12](https://github.com/dfinity/hardware-wallet-cli/security/dependabot/12), [#13](https://github.com/dfinity/hardware-wallet-cli/security/dependabot/13), and [#14](https://github.com/dfinity/hardware-wallet-cli/security/dependabot/14) — the high-severity `esbuild` advisory **GHSA-gv7w-rqvm-qjhr** (missing binary integrity verification in esbuild's Deno module, enabling RCE via `NPM_CONFIG_REGISTRY`). Affects `esbuild < 0.28.1`; we were pinned to `0.25.0`.

`esbuild` is a build-time devDependency used only from Node.js (`node esbuild.mjs`), which performs the SHA-256 binary integrity check. The vulnerable code path lives exclusively in esbuild's **Deno module** (`lib/deno/mod.ts`), which this project never uses — so this is a hygiene bump to clear the alerts rather than a production-affecting fix.

## Change

- Bump `esbuild` `0.25.0 → 0.28.1` in `packages/cli` and `examples/icrc21-swap`.

The bundle build (`pnpm -r run build`) succeeds on the new version; lockfile changes are confined to the `@esbuild/*` platform binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)