### PR TITLE
chore: bump ws to 7.5.11 to resolve Dependabot alert #17

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1734,10 +1734,10 @@ packages:
         integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==,
       }
 
-  ws@7.5.10:
+  ws@7.5.11:
     resolution:
       {
-        integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==,
+        integrity: sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==,
       }
     engines: { node: ">=8.3.0" }
     peerDependencies:
@@ -2365,7 +2365,7 @@ snapshots:
 
   node-window-polyfill@1.0.4:
     dependencies:
-      ws: 7.5.10
+      ws: 7.5.11
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -2615,7 +2615,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@7.5.10: {}
+  ws@7.5.11: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
Resolves Dependabot alert [#17](https://github.com/dfinity/hardware-wallet-cli/security/dependabot/17) (GHSA-96hv-2xvq-fx4p / CVE-2026-48779), a high-severity memory-exhaustion DoS in `ws`.

`ws` is pulled in transitively via `node-window-polyfill`, which is imported in the CLI only to provide a global `window`/`WebSocket` for `TransportWebHID` feature detection — no WebSocket server is run and no untrusted WebSocket connection is opened, so real exposure is minimal. This bump clears the alert regardless.

Bumps `ws` from 7.5.10 to 7.5.11. The patched version satisfies the existing `^7.4.3` range, so the change is confined to the `ws` entries in `pnpm-lock.yaml` and no other resolutions change.